### PR TITLE
raw rulesets

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,16 +6,24 @@ var ov = require('object-values')
 module.exports = gr8util
 
 function gr8util (opts) {
-  return getRulesets({
-    prefixes: getPrefixes(opts.prop),
-    properties: getProperties(opts.prop),
-    suffixes: getSuffixes(opts.vals),
-    values: getValues(opts.vals, opts.transform),
-    join: opts.join,
-    unit: opts.unit,
-    tail: opts.tail,
-    selector: opts.selector || (s => `.${s}`)
-  })
+  if (opts.raw) {
+    return getRawRulesets({
+      entries: opts.raw,
+      tail: opts.tail,
+      selector: opts.selector || (s => `.${s}`)
+    })
+  } else {
+    return getRulesets({
+      prefixes: getPrefixes(opts.prop),
+      properties: getProperties(opts.prop),
+      suffixes: getSuffixes(opts.vals),
+      values: getValues(opts.vals, opts.transform),
+      join: opts.join,
+      unit: opts.unit,
+      tail: opts.tail,
+      selector: opts.selector || (s => `.${s}`)
+    })
+  }
 }
 
 function getPrefixes (input) {
@@ -73,6 +81,18 @@ function getRulesets (opts) {
         opts.tail
       )
     })
+  })
+
+  return flatten(rulesets).join('\n')
+}
+
+function getRawRulesets (opts) {
+  var rulesets = Object.keys(opts.entries).map(function (s) {
+    return ruleset(
+      opts.selector(s),
+      opts.entries[s],
+      opts.tail
+    )
   })
 
   return flatten(rulesets).join('\n')

--- a/test.js
+++ b/test.js
@@ -155,6 +155,23 @@ test('transform {Function}', function (t) {
   t.end()
 })
 
+test('raw', function (t) {
+  var css = util({
+    raw: {
+      'trans-center-x': 'left:50%;transform:translateX(-50%)',
+      'trans-center-y': 'top:50%;transform:translateY(-50%)'
+    }
+  })
+
+  var hasUtil = hasAll([
+    '.trans-center-x{left:50%;transform:translateX(-50%)}',
+    '.trans-center-y{top:50%;transform:translateY(-50%)}'
+  ], css)
+
+  t.ok(hasUtil, css)
+  t.end()
+})
+
 // true if every element is truthy
 function allTruthy (results) {
   return results.every(function (result) {


### PR DESCRIPTION
Adds functionality for more basic rulesets. Mainly useful in the context of [gr8](https://github.com/jongacnik/gr8), when you want utils like this available at all breakpoints. 

```js
var css = util({
  raw: {
    'trans-center-x': 'left:50%;transform:translateX(-50%)',
    'trans-center-y': 'top:50%;transform:translateY(-50%)'
  }
})
```

This isn't necessarily the best api, but will do for now.