### PR TITLE
pseudo option

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ function gr8util (opts) {
       properties: getProperties(opts.prop),
       suffixes: getSuffixes(opts.vals),
       values: getValues(opts.vals, opts.transform),
+      pseudoPrefixes: getPseudoPrefixes(opts.pseudo),
+      pseudoSuffixes: getPseudoSuffixes(opts.pseudo),
       join: opts.join,
       unit: opts.unit,
       tail: opts.tail,
@@ -72,14 +74,41 @@ function getValues (input, transform) {
   return values.map(i => transform(i))
 }
 
+function getPseudoPrefixes (input) {
+  if (!input) return [false]
+  var prefixes = isPlainObj(input)
+    ? Object.keys(input)
+    : ensureArray(input).map(i => {
+      return isPlainObj(i)
+        ? Object.keys(i).pop()
+        : abbreviate(i)
+    })
+  return prefixes
+}
+
+function getPseudoSuffixes (input) {
+  if (!input) return [false]
+  var suffixes = isPlainObj(input)
+    ? ov(input)
+    : ensureArray(input).map(i => {
+      return isPlainObj(i)
+        ? ov(i).pop()
+        : i
+    })
+  return suffixes
+}
+
 function getRulesets (opts) {
   var rulesets = opts.prefixes.map(function (prefix, i) {
     return opts.values.map(function (value, j) {
-      return ruleset(
-        opts.selector(classname(prefix, opts.suffixes[j], opts.join)),
-        declarations(opts.properties[i], value, opts.unit),
-        opts.tail
-      )
+      return opts.pseudoPrefixes.map(function (pseudo, k) {
+        return ruleset(
+          opts.selector(classname(prefix, opts.suffixes[j], opts.join, pseudo)),
+          declarations(opts.properties[i], value, opts.unit),
+          opts.pseudoSuffixes[k],
+          opts.tail
+        )
+      })
     })
   })
 
@@ -125,12 +154,12 @@ function declarations (properties, value, unit) {
     .map(property => declaration(property, value, unit)).join(';')
 }
 
-function ruleset (selector, declaration, tail) {
-  return `${selector}${tail || ''}{${declaration}}`
+function ruleset (selector, declaration, pseudo, tail) {
+  return `${selector}${pseudo ? ':' + pseudo : ''}${tail || ''}{${declaration}}`
 }
 
-function classname (prefix, suffix, join) {
-  return `${prefix}${join || ''}${suffix}`
+function classname (prefix, suffix, join, pseudo) {
+  return `${prefix}${join || ''}${suffix}${pseudo ? '-' + pseudo : ''}`
 }
 
 function declaration (property, value, unit) {

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ Generate a string of css utility rules. `opts` accepts the following values:
 - `opts.prop` **[String | Array | Object]** css property(ies) ***required**
 - `opts.vals` **[Number | String | Array | Object]** css values ***required**
 - `opts.unit` **[String]** unit to append to css values (only appended if values are numeric)
+- `opts.pseudo` **[String | Array | Object]** pseudo selector(s)
 - `opts.tail` **[String]** string to append after selector
 - `opts.join` **[String]** string to join abbreviation and value in selector
 - `opts.selector` **[Function]** css selector template function
@@ -212,7 +213,35 @@ var css = util({
 
 ---
 
-Use `tail` in order to append an arbitrary string to a selector. Exceptionally useful for [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) or [descendant selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_selectors).
+Use `pseudo` in order to generate rules for [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes). Exceptionally useful for hover states.
+
+```js
+var css = util({
+  prop: 'text-transform',
+  vals: [
+    'uppercase',
+    'lowercase'
+  ],
+  pseudo: [
+    'hover',
+    'active',
+    { foc: 'focus' }
+  ]
+})
+```
+
+```css
+.ttu-h:hover{text-transform:uppercase}
+.ttu-a:active{text-transform:uppercase}
+.ttu-foc:focus{text-transform:uppercase}
+.ttl-h:hover{text-transform:lowercase}
+.ttl-a:active{text-transform:lowercase}
+.ttl-foc:focus{text-transform:lowercase}
+```
+
+---
+
+Use `tail` in order to append an arbitrary string to a selector. Exceptionally useful for [descendant selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_selectors).
 
 ```js
 var css = util({

--- a/test.js
+++ b/test.js
@@ -172,6 +172,33 @@ test('raw', function (t) {
   t.end()
 })
 
+test('pseudo', function (t) {
+  var css = util({
+    prop: 'text-transform',
+    vals: [
+      'uppercase',
+      'lowercase'
+    ],
+    pseudo: [
+      'hover',
+      'active',
+      { foc: 'focus' }
+    ]
+  })
+
+  var hasUtil = hasAll([
+    '.ttu-h:hover{text-transform:uppercase}',
+    '.ttu-a:active{text-transform:uppercase}',
+    '.ttu-foc:focus{text-transform:uppercase}',
+    '.ttl-h:hover{text-transform:lowercase}',
+    '.ttl-a:active{text-transform:lowercase}',
+    '.ttl-foc:focus{text-transform:lowercase}'
+  ], css)
+
+  t.ok(hasUtil, css)
+  t.end()
+})
+
 // true if every element is truthy
 function allTruthy (results) {
   return results.every(function (result) {


### PR DESCRIPTION
Adds `pseudo` option for generating rules for pseudo-classes (like hover/active states):

```js
var css = util({
  prop: 'text-transform',
  vals: [
    'uppercase',
    'lowercase'
  ],
  pseudo: [
    'hover',
    'active',
    { foc: 'focus' }
  ]
})
```

```css
.ttu-h:hover{text-transform:uppercase}
.ttu-a:active{text-transform:uppercase}
.ttu-foc:focus{text-transform:uppercase}
.ttl-h:hover{text-transform:lowercase}
.ttl-a:active{text-transform:lowercase}
.ttl-foc:focus{text-transform:lowercase}
```