### PR TITLE
parent option

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function gr8util (opts) {
   if (opts.raw) {
     return getRawRulesets({
       entries: opts.raw,
+      parent: opts.parent,
       tail: opts.tail,
       selector: opts.selector || (s => `.${s}`)
     })
@@ -20,6 +21,7 @@ function gr8util (opts) {
       values: getValues(opts.vals, undefined, opts.transform),
       modifierPrefixes: getKeys(opts.modifiers, i => safeAbbreviate(i), j => prependHyphen(j)),
       modifierSuffixes: getValues(opts.modifiers),
+      parent: opts.parent,
       join: opts.join,
       tail: opts.tail,
       unit: opts.unit,
@@ -55,7 +57,13 @@ function getRulesets (opts) {
       return opts.modifierPrefixes.map(function (modifier, k) {
         var selector = opts.selector(classname(prefix, opts.suffixes[j], opts.join, modifier))
         var declaration = declarations(opts.properties[i], value, opts.unit)
-        return ruleset(selector, declaration, opts.modifierSuffixes[k], opts.tail)
+        return ruleset(
+          selector,
+          declaration,
+          opts.modifierSuffixes[k],
+          opts.tail,
+          opts.parent
+        )
       })
     })
   })
@@ -69,7 +77,8 @@ function getRawRulesets (opts) {
       opts.selector(s),
       opts.entries[s],
       null,
-      opts.tail
+      opts.tail,
+      opts.parent
     )
   })
 
@@ -106,8 +115,8 @@ function declarations (properties, value, unit) {
     .map(property => declaration(property, value, unit)).join(';')
 }
 
-function ruleset (selector, declaration, modifier, tail) {
-  return `${selector}${modifier || ''}${tail || ''}{${declaration}}`
+function ruleset (selector, declaration, modifier, tail, parent) {
+  return `${parent ? parent + ' ' : ''}${selector}${modifier || ''}${tail || ''}{${declaration}}`
 }
 
 function classname (prefix, suffix, join, modifier) {

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ Generate a string of css utility rules. `opts` accepts the following values:
 - `opts.join` **[String]** string to join abbreviation and value in selector
 - `opts.selector` **[Function]** css selector template function
 - `opts.transform` **[Function]** value transform function
+- `opts.parent` **[String]** global parent selector
 
 ## Examples
 
@@ -310,6 +311,29 @@ var css = util({
 .c10{width:83.33333333333334%}
 .c11{width:91.66666666666666%}
 .c12{width:100%}
+```
+
+---
+
+Use `parent` in order to namespace your rules. Useful for conditional utilities:
+
+```js
+var css = util({
+  prop: { fc: 'color' },
+  vals: [
+    'red',
+    'blue',
+    'green'
+  ],
+  modifiers: ':hover',
+  parent: '.no-touch'
+})
+```
+
+```css
+.no-touch .fcr-h:hover{color:red}
+.no-touch .fcb-h:hover{color:blue}
+.no-touch .fcg-h:hover{color:green}
 ```
 
 ## Why

--- a/test.js
+++ b/test.js
@@ -194,6 +194,28 @@ test('modifiers', function (t) {
   t.end()
 })
 
+test('parent', function (t) {
+  var css = util({
+    prop: { fc: 'color' },
+    vals: [
+      'red',
+      'blue',
+      'green'
+    ],
+    modifiers: ':hover',
+    parent: '.no-touch'
+  })
+
+  var hasUtil = hasAll([
+    '.no-touch .fcr-h:hover{color:red}',
+    '.no-touch .fcb-h:hover{color:blue}',
+    '.no-touch .fcg-h:hover{color:green}'
+  ], css)
+
+  t.ok(hasUtil, css)
+  t.end()
+})
+
 // true if every element is truthy
 function allTruthy (results) {
   return results.every(function (result) {


### PR DESCRIPTION
Adds a `parent` option for namespace-ing rules. Useful for conditional utilities:

```js
var css = util({
  prop: { fc: 'color' },
  vals: [
    'red',
    'blue',
    'green'
  ],
  modifiers: ':hover',
  parent: '.no-touch'
})
```

```css
.no-touch .fcr-h:hover{color:red}
.no-touch .fcb-h:hover{color:blue}
.no-touch .fcg-h:hover{color:green}
```